### PR TITLE
Fix tab issue with password confirmation field

### DIFF
--- a/android_app/app/src/main/res/layout/activity_login.xml
+++ b/android_app/app/src/main/res/layout/activity_login.xml
@@ -69,7 +69,8 @@
             android:layout_marginTop="0dp"
             android:hint="@string/prompt_password_confirm"
             android:focusable="false"
-            android:clickable="false">
+            android:clickable="false"
+            android:enabled="false">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/passwordconfirm_field"


### PR DESCRIPTION
Fixes issue on app launch that tab would go to the password confirmation text input field, but not after switching the login/sign up mode.