### PR TITLE
Set Espresso version to highest stable (3.3.0) instead of beta

### DIFF
--- a/android_app/app/build.gradle
+++ b/android_app/app/build.gradle
@@ -31,8 +31,8 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.google.android.material:material:1.3.0'
 
     implementation 'com.amazonaws:aws-android-sdk-auth-userpools:2.22.6'
     implementation 'com.amplifyframework:aws-auth-cognito:1.17.2'
@@ -41,6 +41,6 @@ dependencies {
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'androidx.test:rules:1.3.0-beta01'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0-alpha05'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
 }


### PR DESCRIPTION
Should probably use the stable release like the other dependencies instead of 3.4.0 beta.